### PR TITLE
Handle pagination

### DIFF
--- a/lib/psenv/retriever.rb
+++ b/lib/psenv/retriever.rb
@@ -38,9 +38,16 @@ module Psenv
     end
 
     def parameters
-      ssm.
-        get_parameters_by_path(path: @path, with_decryption: true).
-        parameters
+      parameters = []
+      response = ssm.get_parameters_by_path(path: @path, with_decryption: true)
+      parameters << response.parameters
+
+      while response.next_page?
+        response = response.next_page
+        parameters << response.parameters
+      end
+
+      parameters.flatten
     rescue StandardError => error
       raise RetrieveError, error
     end


### PR DESCRIPTION
AWS Ruby SDK only allows a max result set of 10 from the `get_parameter_by_path` function.  The spec on this is pretty subpar and will be revisited later.